### PR TITLE
Fix bug in strrchr()

### DIFF
--- a/sources/strrchr.c
+++ b/sources/strrchr.c
@@ -2,7 +2,7 @@
 
 char *strrchr(const char *s, int c)
 {
-	const char *cp = s + strlen(s) + 1;
+	const char *cp = s + strlen(s);
 
 	do
 	{


### PR DESCRIPTION
The function started searching one byte behind the terminating null character.