### PR TITLE
stdio: Map newline

### DIFF
--- a/include/stdio.h
+++ b/include/stdio.h
@@ -90,7 +90,6 @@ int puts(const char *s);
 int fputc(int c, FILE *stream);
 int putc(int c, FILE *stream);
 int putchar(int c);
-int puts(const char *s);
 
 int fgetc(FILE *stream);
 char* fgets(char *s, int n, FILE *stream);

--- a/include/stdio.h
+++ b/include/stdio.h
@@ -32,6 +32,9 @@ struct __stdio_file
 
     void *__cookie;			/* Magic cookie. Holds GEMDOS handle */
 	int __pushback;
+#ifdef STDIO_MAP_NEWLINE
+    int __last_char;
+#endif /* defined STDIO_MAP_NEWLINE */
     FILE *__next;     		/* Next FILE in the linked list.  */
 	__io_mode __mode;     /* File access mode.  */
 	unsigned int __eof:1;

--- a/sources/fdopen.c
+++ b/sources/fdopen.c
@@ -75,6 +75,9 @@ FILE *fdopen(int fd, const char *mode)
     fp->__magic = _IOMAGIC;
     FILE_SET_HANDLE(fp, fd);
     fp->__pushback = EOF;
+#ifdef STDIO_MAP_NEWLINE
+    fp->__last_char = EOF;
+#endif /* defined STDIO_MAP_NEWLINE */
     fp->__next = __stdio_head;
     fp->__eof = 0;
     fp->__error = 0;

--- a/sources/fflush.c
+++ b/sources/fflush.c
@@ -3,6 +3,9 @@
 int fflush(FILE *stream)
 {
 	stream->__pushback = EOF;
+#ifdef STDIO_MAP_NEWLINE
+    stream->__last_char = EOF;
+#endif /* defined STDIO_MAP_NEWLINE */
 	return 0;
 }
 

--- a/sources/fopen.c
+++ b/sources/fopen.c
@@ -107,6 +107,9 @@ ok:
 	fp->__magic = _IOMAGIC;
 	FILE_SET_HANDLE(fp, fd);
 	fp->__pushback = EOF;
+#ifdef STDIO_MAP_NEWLINE
+    fp->__last_char = EOF;
+#endif /* defined STDIO_MAP_NEWLINE */
 	fp->__next = __stdio_head;
 	__stdio_head = fp;
 

--- a/sources/fputs.c
+++ b/sources/fputs.c
@@ -35,44 +35,8 @@ fputs(const char* s, FILE* stream)
     size_t len = strlen(s);
     int    ret = len;
 
-    if (len == 1) {
-        if (*s == '\n' && !stream->__mode.__binary && fputc('\r', stream) < 0) {
-            ret = EOF;
-        } else if (fputc(*s, stream) < 0) {
-            ret = EOF;
-        }
-    } else if (stream->__mode.__binary) {
-        if (fwrite(s, sizeof(char), len, stream) != len) {
-            ret = EOF;
-        }
-    } else {
-        char* nl = strchr(s, '\n');
-
-        while (nl != NULL) {
-            if (nl == s || (nl > s && nl[-1] != '\r')) {
-                *nl = '\0';
-                len = strlen(s);
-
-                if (fwrite(s, sizeof(char), len, stream) != len || fwrite("\r\n", sizeof(char), 2, stream) != 2) {
-                    ret = EOF;
-                    *nl = '\n';
-                    break;
-                }
-
-                *nl = '\n';
-                s   = nl + 1;
-            }
-
-            nl = strchr(nl + 1, '\n');
-        }
-
-        if (ret != EOF && s != NULL) {
-            len = strlen(s);
-
-            if (fwrite(s, sizeof(char), len, stream) != len) {
-                ret = EOF;
-            }
-        }
+    if (fwrite(s, sizeof(char), len, stream) != len) {
+        ret = EOF;
     }
 
     return ret;

--- a/sources/fseek.c
+++ b/sources/fseek.c
@@ -29,6 +29,9 @@ int fseek(FILE *fp, long offset, int origin)
 	}
 	fp->__eof = 0;
 	fp->__pushback = EOF;
+#ifdef STDIO_MAP_NEWLINE
+    fp->__last_char = EOF;
+#endif /* defined STDIO_MAP_NEWLINE */
 	return 0;
 }
 

--- a/sources/fwrite.c
+++ b/sources/fwrite.c
@@ -33,9 +33,11 @@ size_t fwrite(const void *ptr, size_t size, size_t nmemb, FILE *stream)
 
             for (put = 0, got = 0; put < limit && got < n; put++, got++)
             {
-                if (str[got] == '\n' && (got == 0 || str[got - 1] != '\r'))
-                    buffer[put++] = '\r';
-                buffer[put] = str[got];
+                if (str[got] == '\n')
+                    if (got == 0 || str[got - 1] != '\r')
+                        if (got > 0 || stream->__last_char != '\r')
+                            buffer[put++] = '\r';
+                stream->__last_char = buffer[put] = str[got];
             }
 
             if (put > 0)

--- a/sources/fwrite.c
+++ b/sources/fwrite.c
@@ -19,7 +19,6 @@ size_t fwrite(const void *ptr, size_t size, size_t nmemb, FILE *stream)
         rc = Fwrite(fd, size * nmemb, ptr);
     } else
     {
-        const char* crlf = "\r\n";
         const unsigned char* str = ptr;
         size_t n = size * nmemb;
 

--- a/sources/rewind.c
+++ b/sources/rewind.c
@@ -13,4 +13,7 @@ void rewind(FILE *stream)
     fseek(stream, 0, SEEK_SET);
     clearerr(stream);
     stream->__pushback = EOF;
+#ifdef STDIO_MAP_NEWLINE
+    stream->__last_char = EOF;
+#endif /* defined STDIO_MAP_NEWLINE */
 }

--- a/sources/stdio.c
+++ b/sources/stdio.c
@@ -6,9 +6,15 @@
 
 FILE *__stdio_head;
 
-FILE _StdInF =  { _IOMAGIC, (void *)0, EOF, NULL, { 1, 0 }, 0, 0 };
-FILE _StdOutF = { _IOMAGIC, (void *)1, EOF, NULL, { 0, 1 }, 0, 0 };
-FILE _StdErrF = { _IOMAGIC, (void *)2, EOF, NULL, { 0, 1 }, 0, 0 };
+#ifdef STDIO_MAP_NEWLINE
+# define LAST_CHAR_INIT  EOF,
+#else
+# define LAST_CHAR_INIT
+#endif /* defined STDIO_MAP_NEWLINE */
+
+FILE _StdInF =  { _IOMAGIC, (void *)0, EOF, LAST_CHAR_INIT NULL, { 1, 0 }, 0, 0 };
+FILE _StdOutF = { _IOMAGIC, (void *)1, EOF, LAST_CHAR_INIT NULL, { 0, 1 }, 0, 0 };
+FILE _StdErrF = { _IOMAGIC, (void *)2, EOF, LAST_CHAR_INIT NULL, { 0, 1 }, 0, 0 };
 
 FILE *stdin = &_StdInF;
 FILE *stdout = &_StdOutF;

--- a/sources/vfprintf.c
+++ b/sources/vfprintf.c
@@ -2,33 +2,14 @@
 #include <stdarg.h>
 #include "lib.h"
 
-static int last_char;
 
 static int fpc(int c, void *fp)
 {
-	int   ret    = '\0';
-	FILE* stream = fp;
-
-	if (!stream->__mode.__binary) {
-		if (c == '\n' && last_char != '\r') {
-			if (putc('\r', stream) == EOF) {
-				ret = EOF;
-			}
-		}
-
-		last_char = c;
-	}
-
-	if (ret != EOF) {
-		ret = putc(c, stream);
-	}
-
-	return ret;
+    FILE* stream = fp;
+    return (putc(c, stream) == EOF) ? 0 : 1;
 }
 
 int vfprintf(FILE *stream, const char *format, va_list ap)
 {
-	return doprnt(fpc, stream, format, ap);
+    return doprnt(fpc, stream, format, ap);
 }
-
-

--- a/sources/vfprintf.c
+++ b/sources/vfprintf.c
@@ -2,18 +2,21 @@
 #include <stdarg.h>
 #include "lib.h"
 
+#ifdef STDIO_MAP_NEWLINE
 static int last_char;
+#endif /* defined STDIO_MAP_NEWLINE */
 
 static int fpc(int c, void *fp)
 {
-	int   ret    = '\0';
 	FILE* stream = fp;
 
+#ifdef STDIO_MAP_NEWLINE
+    int ret = '\0';
+
 	if (!stream->__mode.__binary) {
-		if (c == '\n' && last_char != '\r') {
-			if (putc('\r', stream) == EOF) {
-				ret = EOF;
-			}
+		if (c == '\n' && last_char == '\r') {
+            last_char = c;
+            return 0;
 		}
 
 		last_char = c;
@@ -24,10 +27,17 @@ static int fpc(int c, void *fp)
 	}
 
 	return ret;
+#else
+    return putc(c, stream);
+#endif /* defined STDIO_MAP_NEWLINE */
 }
 
 int vfprintf(FILE *stream, const char *format, va_list ap)
 {
+#ifdef STDIO_MAP_NEWLINE
+    last_char = '\0';
+#endif /* defined STDIO_MAP_NEWLINE */
+
 	return doprnt(fpc, stream, format, ap);
 }
 

--- a/sources/vfprintf.c
+++ b/sources/vfprintf.c
@@ -2,21 +2,18 @@
 #include <stdarg.h>
 #include "lib.h"
 
-#ifdef STDIO_MAP_NEWLINE
 static int last_char;
-#endif /* defined STDIO_MAP_NEWLINE */
 
 static int fpc(int c, void *fp)
 {
+	int   ret    = '\0';
 	FILE* stream = fp;
 
-#ifdef STDIO_MAP_NEWLINE
-    int ret = '\0';
-
 	if (!stream->__mode.__binary) {
-		if (c == '\n' && last_char == '\r') {
-            last_char = c;
-            return 0;
+		if (c == '\n' && last_char != '\r') {
+			if (putc('\r', stream) == EOF) {
+				ret = EOF;
+			}
 		}
 
 		last_char = c;
@@ -27,17 +24,10 @@ static int fpc(int c, void *fp)
 	}
 
 	return ret;
-#else
-    return putc(c, stream);
-#endif /* defined STDIO_MAP_NEWLINE */
 }
 
 int vfprintf(FILE *stream, const char *format, va_list ap)
 {
-#ifdef STDIO_MAP_NEWLINE
-    last_char = '\0';
-#endif /* defined STDIO_MAP_NEWLINE */
-
 	return doprnt(fpc, stream, format, ap);
 }
 


### PR DESCRIPTION
Issue #91

Maybe we can get together at last. I removed the conversion from `fputs()` and `vfprintf()` and had a look at what Mintlib does (see `__stdio_text_write()` in `stdio/sysd-stdio.c`).

I introduced a preprocessor macro `STDIO_MAP_NEWLINE` which has to be defined to enable the automatic conversion. It is disabled by default and has to be enabled explicitly e.g. in `Make.config.local`:

`CFLAGS	= -Werror -O2 -fomit-frame-pointer -DSTDIO_MAP_NEWLINE
`

The conversion is done similar to Mintlib, but in `fwrite()` and only there. The resulting binaries should be smaller no matter if you compile with automatic conversion or not. A simple `printf("Hello World!\n");` will have 12663 vs. 12966 bytes.