### PR TITLE
opendir() possible access before an array.

### DIFF
--- a/sources/opendir.c
+++ b/sources/opendir.c
@@ -57,7 +57,7 @@ DIR *opendir(const char *uname)
                 *p = '\\';
 
         /* make sure the string ends in '\' */
-        if (p != name || *(p-1) != '\\')
+		if (p != name || ((p != name) && (*(p-1) != '\\')) )
         {
             *p++ = '\\';
         }

--- a/sources/opendir.c
+++ b/sources/opendir.c
@@ -57,10 +57,11 @@ DIR *opendir(const char *uname)
                 *p = '\\';
 
         /* make sure the string ends in '\' */
-		if (p != name || ((p != name) && (*(p-1) != '\\')) )
+		if ( (p != name) && (*(p-1) != '\\') )
         {
             *p++ = '\\';
         }
+    
     }
 
     strcpy(p, "*.*");


### PR DESCRIPTION
Reported error by gcc 11. 