### PR TITLE
Use PREFIX_FOR_STARTUP instead of DESTDIR

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -260,7 +260,8 @@ endif
 ifneq (,$(PREFIX_FOR_STARTUP))
 install : install-startup
 install-startup:
-	cp -av $(STARTUPS) $(DESTDIR)/usr/lib
+	@mkdir -pv $(PREFIX_FOR_STARTUP)
+	@cp -av $(STARTUPS) $(PREFIX_FOR_STARTUP)
 endif
 
 ifneq (clean,$(MAKECMDGOALS))


### PR DESCRIPTION
PREFIX_FOR_STARTUP is set to DESTDIR/usr/lib by default.

This fixes building with `make PREFIX_FOR_STARTUP=...`.