### PR TITLE
Check for -ENOTDIR

### DIFF
--- a/sources/remove.c
+++ b/sources/remove.c
@@ -15,7 +15,7 @@ int remove(const char *filename)
 {
 	int ret = Ddelete(filename);
 
-	if (ret == ENOTDIR)
+	if (ret == -ENOTDIR)
 	{
 		ret = Fdelete(filename);
 	}


### PR DESCRIPTION
Ddelete() may return -ENOTDIR (negative), but never ENOTDIR (positive).